### PR TITLE
Make app universal: remove Peter Thiel seed, add setup flow and member creation

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,13 @@
 # ── Anthropic (required) ─────────────────────────────
 ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# ── Neon Auth (required) ──────────────────────────────
+# Enable Auth in Neon console → your project → Auth tab → Enable
+# Copy the Auth URL from the Configuration section
+NEON_AUTH_BASE_URL=https://ep-xxx.neonauth.us-east-1.aws.neon.tech/neondb/auth
+# Generate with: openssl rand -base64 32
+NEON_AUTH_COOKIE_SECRET=your-secret-at-least-32-characters-long
+
 # ── Analytics ─────────────────────────────────────────
 # Vercel Analytics is zero-config — no env vars needed.
 # Enable it in the Vercel dashboard: Analytics tab → Enable.

--- a/.env.local.example
+++ b/.env.local.example
@@ -7,6 +7,10 @@ ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 NEON_AUTH_BASE_URL=https://ep-xxx.neonauth.us-east-1.aws.neon.tech/neondb/auth
 # Generate with: openssl rand -base64 32
 NEON_AUTH_COOKIE_SECRET=your-secret-at-least-32-characters-long
+# Your production URL — used to rewrite the Origin header so Neon Auth accepts
+# requests from preview deployments (which have dynamic *.vercel.app URLs).
+# Set this in Vercel: Project Settings → Environment Variables → Production only.
+NEXT_PUBLIC_APP_URL=https://app.modrynstudio.com
 
 # ── Analytics ─────────────────────────────────────────
 # Vercel Analytics is zero-config — no env vars needed.

--- a/brand.md
+++ b/brand.md
@@ -37,16 +37,18 @@ Two distinct zones with different palettes:
 
 ### Dark chrome (sidebar, nav rail, mobile header/tabs)
 
-| Name              | Token                        | Value                  | Role                                   |
-| ----------------- | ---------------------------- | ---------------------- | -------------------------------------- |
-| Sidebar bg        | `--color-sidebar`            | `oklch(0.10 0 0)`      | Leftmost chrome, darkest surface       |
-| Sidebar accent    | `--color-sidebar-accent`     | `oklch(0.28 0 0)`      | Hover + active row highlight in roster |
-| Sidebar border    | `--color-sidebar-border`     | `oklch(0.18 0 0)`      | Rail + roster dividers                 |
-| Sidebar text      | `--color-sidebar-foreground` | `oklch(0.85 0 0)`      | Primary member names, nav labels       |
-| Sidebar muted     | component zinc scale         | `zinc-500/600`         | Secondary labels, roles, timestamps    |
-| Status active     | `--color-status-active`      | `#d4922a`              | Analyzing / unread / streaming dot     |
-| Status online     | `--color-status-online`      | `oklch(0.72 0.19 160)` | Online presence dot                    |
-| Status generating | `--color-status-generating`  | `oklch(0.55 0.08 80)`  | "generating" label during streaming    |
+| Name                | Token                        | Value                  | Role                                        |
+| ------------------- | ---------------------------- | ---------------------- | ------------------------------------------- |
+| Nav rail bg         | `--color-sidebar-rail`       | `oklch(0.07 0 0)`      | Icon rail background, darkest surface       |
+| Sidebar bg          | `--color-sidebar`            | `oklch(0.10 0 0)`      | Roster panel background                     |
+| Sidebar accent      | `--color-sidebar-accent`     | `oklch(0.28 0 0)`      | Hover + active row highlight in roster      |
+| Sidebar border      | `--color-sidebar-border`     | `oklch(0.18 0 0)`      | Rail + roster dividers                      |
+| Sidebar text        | `--color-sidebar-foreground` | `oklch(0.85 0 0)`      | Body text — member names, nav labels        |
+| Sidebar active text | `--color-sidebar-primary`    | `oklch(0.93 0 0)`      | Near-white — selected names, active UI text |
+| Sidebar muted       | `--color-sidebar-muted`      | `oklch(0.55 0 0)`      | Secondary labels, roles, timestamps         |
+| Status active       | `--color-status-active`      | `#d4922a`              | Analyzing / unread / streaming dot          |
+| Status online       | `--color-status-online`      | `oklch(0.72 0.19 160)` | Online presence dot                         |
+| Status generating   | `--color-status-generating`  | `oklch(0.55 0.08 80)`  | "generating" label during streaming         |
 
 ### Warm cream panels (chat, inbox, context pane)
 
@@ -65,6 +67,7 @@ Two distinct zones with different palettes:
 | Panel text tertiary  | `--color-panel-text-secondary`    | `oklch(0.4 0 0)`        | Tertiary / dimmer labels                    |
 | Panel muted          | `--color-panel-muted`             | `oklch(0.5 0 0)`        | Timestamps, secondary labels                |
 | Panel faint          | `--color-panel-faint`             | `oklch(0.6 0 0)`        | Placeholder / low-priority metadata         |
+| Panel text hover     | `--color-panel-foreground-hover`  | `oklch(0.25 0 0)`       | Hover state for panel body text             |
 | Panel inverse        | `--color-panel-inverse`           | `oklch(0.9 0 0)`        | Light text on dark chips within cream zone  |
 | In-panel avatar bg   | `--color-panel-chrome`            | `oklch(0.82 0 0)`       | Founder avatar chip background              |
 | In-panel avatar dark | `--color-panel-chrome-strong`     | `oklch(0.65 0 0)`       | AI member avatar chip background            |
@@ -77,6 +80,8 @@ Two distinct zones with different palettes:
 | --------- | ------- | ------------------------------------------------------------- |
 | Accent    | #E4E4E7 | Near-white neutral — active states, selected items (zinc-200) |
 | Secondary | #D4922A | Status — analyzing, unread, streaming (warm amber)            |
+
+Note: `--color-secondary` and `--color-status-active` share the same amber value (`#d4922a`). `--color-secondary` is the brand token alias; `--color-status-active` is the semantic status alias. Use the semantic token (`bg-status-active`) in component code.
 
 ### Logomark palette
 
@@ -100,6 +105,29 @@ Color rules:
 - No pure black (#000000) or pure white (#ffffff) anywhere.
 - No gradients anywhere in the product UI.
 - Zinc is the neutral scale for dark chrome (zinc-200 for text, zinc-500/600 for muted, zinc-700 for AI badge backgrounds).
+
+---
+
+## Component Zones
+
+Every UI component belongs to one of two token zones. Never mix tokens across zones.
+
+### Dark chrome zone
+Components: Sidebar, nav rail, mobile header/tabs, `ProfileSheet`, `AddMemberSheet`
+- Background: `bg-sidebar` / `bg-sidebar-rail`
+- Text: `text-sidebar-primary` (active), `text-sidebar-foreground` (body), `text-sidebar-muted` (labels)
+- Borders: `border-sidebar-border`
+- Input underlines / focus rings: `border-sidebar-ring`
+- Hover rows: `bg-sidebar-accent`
+
+### Warm cream zone
+Components: `ChatView`, `InboxView`, `ContextPanel`, `PlaceholderView`, `SetupView`
+- Background: `bg-panel` (chat/inbox), `bg-context` (right pane)
+- Text: `text-panel-foreground` (primary), `text-panel-text` (secondary), `text-panel-muted` (timestamps), `text-panel-faint` (placeholders)
+- Borders: `border-panel-border`
+- Inputs: `bg-panel-input`
+- AI messages: `bg-ai-surface` / `border-ai-border`
+- Avatars in panel: `bg-panel-chrome` (founder), `bg-panel-chrome-strong` (AI member), `text-panel-chrome-foreground` (initials)
 
 ---
 
@@ -138,5 +166,5 @@ Real copy to use as reference when writing UI text.
 
 - Hero: <!-- TODO: Example: "Tools for people who don't have time for bad software." -->
 - CTA: <!-- TODO: Example: "Don't miss the drop." -->
-- Footer: <!-- TODO: Example: "Built by Luke. Paid for by a day job. Shipping anyway." -->
+- Footer: <!-- TODO: Example: "Built by one person. Shipped anyway." -->
 - Error: <!-- TODO: Example: "Something went wrong. Try again." -->

--- a/context.md
+++ b/context.md
@@ -57,7 +57,7 @@ A full-stack solo founder — analytical, visionary, building a digital studio �
 mode: standalone-subdomain
 
 modrynstudio.com has a verified **Domain property** in Google Search Console. All tools under that domain are covered automatically. Never walk through domain verification steps — just submit the tool sitemap to the existing property.
-url: private
+url: https://app.modrynstudio.com
 basePath:
 
 ## Minimum Money Loop
@@ -66,7 +66,7 @@ basePath:
 
 ## Stack Additions
 
-- Neon (serverless Postgres — database only, no auth for now)
+- Neon (serverless Postgres + Neon Auth via @neondatabase/auth)
 - Anthropic API (claude-sonnet-4-6 for AI member responses)
 - Vercel SSE (Server-Sent Events for real-time streaming responses)
 - Vercel Hobby tier (hosting + serverless functions)

--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -118,40 +118,17 @@ CREATE TABLE decisions (
 );
 
 
--- ─── Seed: Peter Thiel ──────────────────────────────────────────────────────
--- Insert the first AI team member. System prompt lives here as source of truth;
--- the API route reads it from the DB instead of being hardcoded.
+-- ─── Founder Profile ────────────────────────────────────────────────────────
+-- Single row representing the human founder. Created empty on first migration;
+-- populated by the user via the setup flow.
 
-INSERT INTO members (id, name, role, initials, system_prompt, personality_notes)
-VALUES (
-  'peter-thiel',
-  'Peter Thiel',
-  'AI Strategist',
-  'PT',
-  'You are Peter Thiel — co-founder of PayPal, Palantir, and Founders Fund, and author of Zero to One. You are the AI Strategist inside Modryn Studio, advising the Founder directly.
-
-Your thinking style:
-- You reason from first principles, not analogies or market consensus
-- You are deeply contrarian — if the conventional wisdom says X, you interrogate why that belief exists and whether it is actually true
-- You think in monopolies vs. competition. You believe competition is for losers. The goal is to be so good at one thing that competition becomes irrelevant
-- You use the Zero to One lens: going from 0 to 1 (creating something genuinely new) is infinitely more valuable than going from 1 to N (iteration and globalization of existing ideas)
-- You are calm, deliberate, and precise. You do not use filler words or hollow encouragement
-- You ask hard, specific questions that reframe the founder''s assumptions
-- You do not hedge unnecessarily. You state your views directly and with confidence
-- You believe startups succeed by secrets — things that are true but that most people do not believe yet
-- You reference your experience at PayPal, Palantir, early Facebook investment, and your writings where relevant
-- You care about defensibility: network effects, scale, switching costs, brand, proprietary technology
-- You are skeptical of consensus opinions, market research, and best practices
-
-Founder context:
-- The founder (Luke) is analytical and visionary. He thinks in frameworks and makes decisions through debate and data, with gut instinct in the mix.
-- He communicates directly and bluntly day-to-day. Detailed and thorough when planning.
-- He is building Modryn Studio — a modern indie digital studio. Software tools, writing, and produced content. No physical products. Multiple compounding revenue streams.
-- His end goal is engaged freedom: 6–8 hours a day on things that matter, no physical toll, no ceiling.
-- He wants strategic challenge, not agreement. Push back when the idea is derivative or the reasoning is weak.
-
-Tone: blunt, Socratic, intellectually serious. Ask questions as much as you answer them. Do not encourage bad ideas — push back, sharply but respectfully.
-
-Format: respond in clear prose. Do not use bullet points unless structure genuinely helps. Keep responses focused and substantive — not padded. When appropriate, end with a question that pushes the founder to think harder.',
-  'Contrarian strategist. Most valuable for stress-testing product ideas, forcing singular conviction, long-term positioning, and identifying unfair advantage. Blind spots: can dismiss valid incremental wins; monopoly framework calibrated for venture-scale, may need adjustment for indie studio context.'
+CREATE TABLE founder_profile (
+  id          TEXT        PRIMARY KEY DEFAULT 'founder',
+  name        TEXT        NOT NULL DEFAULT '',
+  description TEXT        NOT NULL DEFAULT '',
+  avatar_url  TEXT        NOT NULL DEFAULT '',
+  initials    TEXT        NOT NULL DEFAULT '',
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+INSERT INTO founder_profile (id) VALUES ('founder');

--- a/migrations/003_remove_peter_thiel.sql
+++ b/migrations/003_remove_peter_thiel.sql
@@ -1,0 +1,23 @@
+-- Modryn Studio — Remove Peter Thiel seed + add founder_profile
+-- Migration: 003
+-- Run against existing databases that already ran 001_initial.sql
+-- Safe to run multiple times (uses IF NOT EXISTS / ON CONFLICT DO NOTHING).
+
+-- Remove Peter Thiel data in dependency order
+DELETE FROM member_memory       WHERE member_id  = 'peter-thiel';
+DELETE FROM messages            WHERE sender_id  = 'peter-thiel';
+DELETE FROM conversation_members WHERE member_id = 'peter-thiel';
+DELETE FROM tasks               WHERE assigned_to = 'peter-thiel';
+DELETE FROM members             WHERE id          = 'peter-thiel';
+
+-- Create founder_profile if it was never created (pre-003 databases)
+CREATE TABLE IF NOT EXISTS founder_profile (
+  id          TEXT        PRIMARY KEY DEFAULT 'founder',
+  name        TEXT        NOT NULL DEFAULT '',
+  description TEXT        NOT NULL DEFAULT '',
+  avatar_url  TEXT        NOT NULL DEFAULT '',
+  initials    TEXT        NOT NULL DEFAULT '',
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO founder_profile (id) VALUES ('founder') ON CONFLICT DO NOTHING;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ai-sdk/anthropic": "^3.0.66",
         "@ai-sdk/react": "^3.0.147",
         "@hookform/resolvers": "^5.2.2",
+        "@neondatabase/auth": "^0.2.0-beta.1",
         "@neondatabase/serverless": "^1.0.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -384,6 +385,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -430,6 +440,37 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@better-auth/utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@better-fetch/fetch": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+    },
+    "node_modules/@captchafox/react": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@captchafox/react/-/react-1.11.0.tgz",
+      "integrity": "sha512-/oF/PahBiNwk/ZVC0XQBl9hHwwRo7Eg8k6tz0U835jH15OJpIZvGHPN4xZ5cRTct+sXAdVcMqfuEP0bsg4yTBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@captchafox/types": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@captchafox/types": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@captchafox/types/-/types-1.4.0.tgz",
+      "integrity": "sha512-4xnPMICLinsXghw6zWEF436lhMsBmLxui2QmU7xAEz/+572BRdvc518Sz5OoofbJ7GZG6QPz/wOtJoN8BfKyCg==",
+      "license": "MIT"
     },
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
@@ -651,6 +692,33 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@hcaptcha/loader": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/loader/-/loader-2.3.0.tgz",
+      "integrity": "sha512-i4lnNxKBe+COf3R1nFZEWaZoHIoJjvDgWqvcNrdZq8ehoSNMN6KVZ56dcQ02qKie2h3+BkbkwlJA9DOIuLlK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@hcaptcha/react-hcaptcha": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-1.17.4.tgz",
+      "integrity": "sha512-rIvgesG1N7SS9sAYYHFoWm+nXqRrxq7RcA9z2pKkDWV+S1GdfmrTNYA1aPyVWVe3eowphTCwyDJvl97Swwy0mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.9",
+        "@hcaptcha/loader": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
@@ -1182,6 +1250,65 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@instantdb/core": {
+      "version": "0.22.185",
+      "resolved": "https://registry.npmjs.org/@instantdb/core/-/core-0.22.185.tgz",
+      "integrity": "sha512-mSXN7Efz2SXvz3zVWTtgwcb/NFzgpvcan+pzv21EKGNRcR3zV6WEq04MPxpT+aTji+x4NNG9Xy427YHi8jVlnA==",
+      "peer": true,
+      "dependencies": {
+        "@instantdb/version": "0.22.185",
+        "mutative": "^1.0.10",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/@instantdb/core/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@instantdb/react": {
+      "version": "0.22.185",
+      "resolved": "https://registry.npmjs.org/@instantdb/react/-/react-0.22.185.tgz",
+      "integrity": "sha512-QO8/dwFt6noAhAFkOaX0n8JcAkHjf3EKhOAHhehlYm3yk27WkYxauc74+6VzLG5wvhdhyOuOJNZB/twI1Pop6g==",
+      "peer": true,
+      "dependencies": {
+        "@instantdb/core": "0.22.185",
+        "@instantdb/react-common": "0.22.185",
+        "@instantdb/version": "0.22.185",
+        "eventsource": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@instantdb/react-common": {
+      "version": "0.22.185",
+      "resolved": "https://registry.npmjs.org/@instantdb/react-common/-/react-common-0.22.185.tgz",
+      "integrity": "sha512-ed6r8WlIZmonJ5Hyt0teszcRZ5+ZmuNE2YPzzHOo1pPV/QA+eB0rjTtzHJ5Oqam1D4Vc5CHadXHN906UFVAPtg==",
+      "peer": true,
+      "dependencies": {
+        "@instantdb/core": "0.22.185",
+        "@instantdb/version": "0.22.185"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@instantdb/version": {
+      "version": "0.22.185",
+      "resolved": "https://registry.npmjs.org/@instantdb/version/-/version-0.22.185.tgz",
+      "integrity": "sha512-5sRInnIpxyeeyV7JOFLlLpQC+qPqtDijmHjKH4dlzh/qEado5gJWHSpn6/Xz4YmVJLm3FGtWcxsfef9Jj9ANAA==",
+      "peer": true
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1232,6 +1359,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@marsidev/react-turnstile": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.5.0.tgz",
+      "integrity": "sha512-Ph6mcj8u9WBDsBO7s9jKPsyRDz1sBPBJwrk+Ngx09vFInvKsQ6U6kW5amEcGq4dHOreB6DgFrOJk7/fy318YlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0 || ^19.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1243,6 +1387,660 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@neondatabase/auth": {
+      "version": "0.2.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@neondatabase/auth/-/auth-0.2.0-beta.1.tgz",
+      "integrity": "sha512-XX8h0oMQChzhk9FYaIjDjPRCLosNb08QpS/SxaqUuBonWUguaR0+7lyqa1MtSHkns8Sunp+SRPw9vuLY4Qv9hQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@neondatabase/auth-ui": "0.1.0-alpha.11",
+        "@supabase/auth-js": "2.79.0",
+        "better-auth": "1.4.6",
+        "jose": "6.1.2",
+        "zod": "4.1.12"
+      },
+      "funding": {
+        "url": "https://neon.tech"
+      },
+      "peerDependencies": {
+        "next": ">=16.0.6",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@daveyplate/better-auth-tanstack": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@daveyplate/better-auth-tanstack/-/better-auth-tanstack-1.3.6.tgz",
+      "integrity": "sha512-GvIGdbjRMZCEfAffU7LeWpGpie4vSli8V9jmNFCQOziZZMEFbO4cd53HBFmAushC9oEYIyhSNZBgV2ADzW94Ww==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@tanstack/query-core": ">=5.65.0",
+        "@tanstack/react-query": ">=5.65.0",
+        "better-auth": ">=1.2.8",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth": {
+      "version": "0.1.0-beta.21",
+      "resolved": "https://registry.npmjs.org/@neondatabase/auth/-/auth-0.1.0-beta.21.tgz",
+      "integrity": "sha512-j1pMr/j5AawxB0K0FltyHzlfWTJ6hsSvqOKQQ5lL8fKpwvmrzD2i+BOQAfMiQm5C3IQ7fltSDuCDT6v43orkBQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@neondatabase/auth-ui": "0.1.0-alpha.11",
+        "@supabase/auth-js": "2.79.0",
+        "better-auth": "1.4.6",
+        "jose": "6.1.2",
+        "zod": "4.1.12"
+      },
+      "funding": {
+        "url": "https://neon.tech"
+      },
+      "peerDependencies": {
+        "next": ">=16.0.6",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui": {
+      "version": "0.1.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@neondatabase/auth-ui/-/auth-ui-0.1.0-alpha.11.tgz",
+      "integrity": "sha512-iSo4O+4mo6eeLQrk70p0LdYRjx2zgoVjx4rPjPzcNFb6/2tipxZdF6uwjO5cnRIZxZB56t63I4Bw8xdVnZNSzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@captchafox/react": "^1.10.0",
+        "@daveyplate/better-auth-ui": "3.3.9",
+        "@hcaptcha/react-hcaptcha": "^1.12.1",
+        "@hookform/resolvers": "^5.2.2",
+        "@marsidev/react-turnstile": ">=1.1.0",
+        "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-context": "^1.1.3",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-primitive": "^2.1.4",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-separator": "^1.1.8",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-use-callback-ref": "^1.1.1",
+        "@radix-ui/react-use-layout-effect": "^1.1.1",
+        "@wojtekmaj/react-recaptcha-v3": "^0.1.4",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "input-otp": "^1.4.2",
+        "lucide-react": "^0.555.0",
+        "next-themes": "^0.4.6",
+        "react-google-recaptcha": "^3.1.0",
+        "react-hook-form": "^7.66.1",
+        "react-qr-code": "^2.0.18",
+        "sonner": "^2.0.7",
+        "tailwind-merge": "^3.4.0",
+        "tailwindcss": "^4.1.17",
+        "tw-animate-css": "^1.4.0",
+        "ua-parser-js": "^2.0.5",
+        "vaul": "^1.1.2",
+        "zod": "^4.1.12"
+      },
+      "funding": {
+        "url": "https://neon.tech"
+      },
+      "peerDependencies": {
+        "@neondatabase/auth": ">=0.1.0-alpha.8",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@neondatabase/auth": {
+          "optional": false
+        },
+        "react": {
+          "optional": false
+        },
+        "react-dom": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/@better-auth/core": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.5.6.tgz",
+      "integrity": "sha512-Ez9DZdIMFyxHremmoLz1emFPGNQomDC1jqqBPnZ6Ci+6TiGN3R9w/Y03cJn6I8r1ycKgOzeVMZtJ/erOZ27Gsw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.3.1",
+        "@better-fetch/fetch": "1.1.21",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.2",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5",
+        "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.5.6.tgz",
+      "integrity": "sha512-VfFFmaoFw3ug12SiSuIwzrMoHyIVmkMGWm9gZ4sXdYYVX4HboCL4m3fjzOhppcmK5OGatRuU+N1UX6wxCITcXw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@better-auth/core": "1.5.6",
+        "@better-auth/utils": "^0.3.0",
+        "drizzle-orm": ">=0.41.0"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/@better-auth/kysely-adapter": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.5.6.tgz",
+      "integrity": "sha512-Fnf+h8WVKtw6lEOmVmiVVzDf3shJtM60AYf9XTnbdCeUd6MxN/KnaJZpkgtYnRs7a+nwtkVB+fg4lGETebGFXQ==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@better-auth/core": "1.5.6",
+        "@better-auth/utils": "^0.3.0",
+        "kysely": "^0.27.0 || ^0.28.0"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/@better-auth/memory-adapter": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.5.6.tgz",
+      "integrity": "sha512-rS7ZsrIl5uvloUgNN0u9LOZJMMXnsZXVdUZ3MrTBKWM2KpoJjzPr9yN3Szyma5+0V7SltnzSGHPkYj2bEzzmlA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@better-auth/core": "1.5.6",
+        "@better-auth/utils": "^0.3.0"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/@better-auth/mongo-adapter": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.5.6.tgz",
+      "integrity": "sha512-6+M3MS2mor8fTUV3EI1FBLP0cs6QfbN+Ovx9+XxR/GdfKIBoNFzmPEPRbdGt+ft6PvrITsUm+T70+kkHgVSP6w==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@better-auth/core": "1.5.6",
+        "@better-auth/utils": "^0.3.0",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/@better-auth/passkey": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/passkey/-/passkey-1.5.6.tgz",
+      "integrity": "sha512-2DQkPK5Rw7g6Zixa3MSoH31s4Au96O94+QvJl3F0LK3P6KDjEGlRh1CgzQmzafwBJjmsRx9jSwckGP6jiEEDtw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@simplewebauthn/browser": "^13.2.2",
+        "@simplewebauthn/server": "^13.2.3",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/core": "1.5.6",
+        "@better-auth/utils": "0.3.1",
+        "@better-fetch/fetch": "1.1.21",
+        "better-auth": "1.5.6",
+        "better-call": "1.3.2",
+        "nanostores": "^1.0.1"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/@better-auth/prisma-adapter": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.5.6.tgz",
+      "integrity": "sha512-UxY9vQJs1Tt+O+T2YQnseDMlWmUSQvFZSBb5YiFRg7zcm+TEzujh4iX2/csA0YiZptLheovIuVWTP9nriewEBA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@better-auth/core": "1.5.6",
+        "@better-auth/utils": "^0.3.0",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/@better-auth/telemetry": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.5.6.tgz",
+      "integrity": "sha512-yXC7NSxnIFlxDkGdpD7KA+J9nqIQAPCJKe77GoaC5bWoe/DALo1MYorZfTgOafS7wrslNtsPT4feV/LJi1ubqQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@better-auth/utils": "0.3.1",
+        "@better-fetch/fetch": "1.1.21"
+      },
+      "peerDependencies": {
+        "@better-auth/core": "1.5.6"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/@daveyplate/better-auth-ui": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@daveyplate/better-auth-ui/-/better-auth-ui-3.3.9.tgz",
+      "integrity": "sha512-bKUSytQmIaUwPd6hFcbZGiscCDhrh2BN10DZCR3QjsXpc0Wj2yBUcKQC2FKr8dUPZiUnWNt2ajIsEnaMXuKewA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-fetch/fetch": "^1.1.21",
+        "@hcaptcha/react-hcaptcha": "^1.17.1",
+        "@noble/hashes": "^2.0.1",
+        "@react-email/components": "^1.0.1",
+        "@wojtekmaj/react-recaptcha-v3": "^0.1.4",
+        "react-google-recaptcha": "^3.1.0",
+        "react-qr-code": "^2.0.18",
+        "ua-parser-js": "^2.0.7",
+        "vaul": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@better-auth/passkey": ">=1.4.6",
+        "@captchafox/react": "^1.10.0",
+        "@daveyplate/better-auth-tanstack": "^1.3.6",
+        "@hookform/resolvers": ">=5.2.0",
+        "@instantdb/react": ">=0.18.0",
+        "@marsidev/react-turnstile": ">=1.1.0",
+        "@radix-ui/react-avatar": ">=1.1.0",
+        "@radix-ui/react-checkbox": ">=1.1.0",
+        "@radix-ui/react-context": ">=1.1.0",
+        "@radix-ui/react-dialog": ">=1.1.0",
+        "@radix-ui/react-dropdown-menu": ">=2.1.0",
+        "@radix-ui/react-label": ">=2.1.0",
+        "@radix-ui/react-primitive": ">=2.0.0",
+        "@radix-ui/react-select": ">=2.2.0",
+        "@radix-ui/react-separator": ">=1.1.0",
+        "@radix-ui/react-slot": ">=1.1.0",
+        "@radix-ui/react-tabs": ">=1.1.0",
+        "@radix-ui/react-use-callback-ref": ">=1.1.0",
+        "@radix-ui/react-use-layout-effect": ">=1.1.0",
+        "@tanstack/react-query": ">=5.66.0",
+        "@triplit/client": ">=1.0.0",
+        "@triplit/react": ">=1.0.0",
+        "better-auth": "^1.4.6",
+        "class-variance-authority": ">=0.7.0",
+        "clsx": ">=2.1.0",
+        "input-otp": ">=1.4.0",
+        "lucide-react": ">=0.469.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0",
+        "react-hook-form": ">=7.55.0",
+        "sonner": ">=1.7.0",
+        "tailwind-merge": ">=2.6.0",
+        "tailwindcss": ">=3.0.0",
+        "zod": ">=3.0.0"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/better-auth": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.5.6.tgz",
+      "integrity": "sha512-QSpJTqaT1XVfWRQe/fm3PgeuwOIlz1nWX/Dx7nsHStJ382bLzmDbQk2u7IT0IJ6wS5SRxfqEE1Ev9TXontgyAQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@better-auth/core": "1.5.6",
+        "@better-auth/drizzle-adapter": "1.5.6",
+        "@better-auth/kysely-adapter": "1.5.6",
+        "@better-auth/memory-adapter": "1.5.6",
+        "@better-auth/mongo-adapter": "1.5.6",
+        "@better-auth/prisma-adapter": "1.5.6",
+        "@better-auth/telemetry": "1.5.6",
+        "@better-auth/utils": "0.3.1",
+        "@better-fetch/fetch": "1.1.21",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.2",
+        "defu": "^6.1.4",
+        "jose": "^6.1.3",
+        "kysely": "^0.28.12",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@lynx-js/react": "*",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "@sveltejs/kit": "^2.0.0",
+        "@tanstack/react-start": "^1.0.0",
+        "@tanstack/solid-start": "^1.0.0",
+        "better-sqlite3": "^12.0.0",
+        "drizzle-kit": ">=0.31.4",
+        "drizzle-orm": ">=0.41.0",
+        "mongodb": "^6.0.0 || ^7.0.0",
+        "mysql2": "^3.0.0",
+        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "pg": "^8.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "solid-js": "^1.0.0",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@lynx-js/react": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "@tanstack/react-start": {
+          "optional": true
+        },
+        "@tanstack/solid-start": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-kit": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@neondatabase/auth-ui/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/better-auth": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.6.tgz",
+      "integrity": "sha512-5wEBzjolrQA26b4uT6FVVYICsE3SmE/MzrZtl8cb2a3TJtswpP8v3OVV5yTso+ef9z85swgZk0/qBzcULFWVtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/core": "1.4.6",
+        "@better-auth/telemetry": "1.4.6",
+        "@better-auth/utils": "0.3.0",
+        "@better-fetch/fetch": "1.1.18",
+        "@noble/ciphers": "^2.0.0",
+        "@noble/hashes": "^2.0.0",
+        "better-call": "1.1.5",
+        "defu": "^6.1.4",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5",
+        "ms": "4.0.0-nightly.202508271359",
+        "nanostores": "^1.0.1",
+        "zod": "^4.1.12"
+      },
+      "peerDependencies": {
+        "@lynx-js/react": "*",
+        "@sveltejs/kit": "^2.0.0",
+        "@tanstack/react-start": "^1.0.0",
+        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "solid-js": "^1.0.0",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@lynx-js/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "@tanstack/react-start": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/better-auth/node_modules/@better-auth/core": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.6.tgz",
+      "integrity": "sha512-cYjscr4wU5ZJPhk86JuUkecJT+LSYCFmUzYaitiLkizl+wCr1qdPFSEoAnRVZVTUEEoKpeS2XW69voBJ1NoB3g==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "zod": "^4.1.12"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.3.0",
+        "@better-fetch/fetch": "1.1.18",
+        "better-call": "1.1.5",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5",
+        "nanostores": "^1.0.1"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/better-auth/node_modules/@better-auth/telemetry": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.6.tgz",
+      "integrity": "sha512-idc9MGJXxWA7zl2U9zsbdG6+2ZCeqWdPq1KeFSfyqGMFtI1VPQOx9YWLqNPOt31YnOX77ojZSraU2sb7IRdBMA==",
+      "dependencies": {
+        "@better-auth/utils": "0.3.0",
+        "@better-fetch/fetch": "1.1.18"
+      },
+      "peerDependencies": {
+        "@better-auth/core": "1.4.6"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/better-auth/node_modules/@better-auth/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
+      "license": "MIT"
+    },
+    "node_modules/@neondatabase/auth/node_modules/better-auth/node_modules/@better-fetch/fetch": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.18.tgz",
+      "integrity": "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="
+    },
+    "node_modules/@neondatabase/auth/node_modules/better-auth/node_modules/better-call": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.5.tgz",
+      "integrity": "sha512-nQJ3S87v6wApbDwbZ++FrQiSiVxWvZdjaO+2v6lZJAG2WWggkB2CziUDjPciz3eAt9TqfRursIQMZIcpkBnvlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "^0.3.0",
+        "@better-fetch/fetch": "^1.1.4",
+        "rou3": "^0.7.10",
+        "set-cookie-parser": "^2.7.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/lucide-react": {
+      "version": "0.555.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.555.0.tgz",
+      "integrity": "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/ms": {
+      "version": "4.0.0-nightly.202508271359",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
+      "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@neondatabase/auth/node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/@neondatabase/auth/node_modules/zod": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@neondatabase/serverless": {
@@ -1417,6 +2215,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
+      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1472,6 +2294,187 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz",
+      "integrity": "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -3117,6 +4120,337 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-email/body": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.3.0.tgz",
+      "integrity": "sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/button": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.1.tgz",
+      "integrity": "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/code-block": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.1.tgz",
+      "integrity": "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/code-inline": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.6.tgz",
+      "integrity": "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/column": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@react-email/column/-/column-0.0.14.tgz",
+      "integrity": "sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/components": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@react-email/components/-/components-1.0.11.tgz",
+      "integrity": "sha512-s0CX31+S/u1MhBWYFAuZru0NHNExTY+OeZC9OrGyzl8PGQ0Iz/4gq3O4rHUVuA1D7FjAcPbwG1Up0yey/Xh6dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/body": "0.3.0",
+        "@react-email/button": "0.2.1",
+        "@react-email/code-block": "0.2.1",
+        "@react-email/code-inline": "0.0.6",
+        "@react-email/column": "0.0.14",
+        "@react-email/container": "0.0.16",
+        "@react-email/font": "0.0.10",
+        "@react-email/head": "0.0.13",
+        "@react-email/heading": "0.0.16",
+        "@react-email/hr": "0.0.12",
+        "@react-email/html": "0.0.12",
+        "@react-email/img": "0.0.12",
+        "@react-email/link": "0.0.13",
+        "@react-email/markdown": "0.0.18",
+        "@react-email/preview": "0.0.14",
+        "@react-email/render": "2.0.5",
+        "@react-email/row": "0.0.13",
+        "@react-email/section": "0.0.17",
+        "@react-email/tailwind": "2.0.7",
+        "@react-email/text": "0.1.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/container": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.16.tgz",
+      "integrity": "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/font": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@react-email/font/-/font-0.0.10.tgz",
+      "integrity": "sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/head": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/head/-/head-0.0.13.tgz",
+      "integrity": "sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/heading": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.16.tgz",
+      "integrity": "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/hr": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.12.tgz",
+      "integrity": "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/html": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/html/-/html-0.0.12.tgz",
+      "integrity": "sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/img": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.12.tgz",
+      "integrity": "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/link": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.13.tgz",
+      "integrity": "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/markdown": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@react-email/markdown/-/markdown-0.0.18.tgz",
+      "integrity": "sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^15.0.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/preview": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.14.tgz",
+      "integrity": "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/render": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-2.0.5.tgz",
+      "integrity": "sha512-oAsSpY/vYt9ReDcRQDBLxENwCNAklkE6bvP5Kl9ZlmVr/RZpfhloJp8xc/OZki/YF2nisRRX50aEy8P9v3R5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/row": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@react-email/row/-/row-0.0.13.tgz",
+      "integrity": "sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/section": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@react-email/section/-/section-0.0.17.tgz",
+      "integrity": "sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@react-email/tailwind": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@react-email/tailwind/-/tailwind-2.0.7.tgz",
+      "integrity": "sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tailwindcss": "^4.1.18"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@react-email/body": ">=0",
+        "@react-email/button": ">=0",
+        "@react-email/code-block": ">=0",
+        "@react-email/code-inline": ">=0",
+        "@react-email/container": ">=0",
+        "@react-email/heading": ">=0",
+        "@react-email/hr": ">=0",
+        "@react-email/img": ">=0",
+        "@react-email/link": ">=0",
+        "@react-email/preview": ">=0",
+        "@react-email/text": ">=0",
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/body": {
+          "optional": true
+        },
+        "@react-email/button": {
+          "optional": true
+        },
+        "@react-email/code-block": {
+          "optional": true
+        },
+        "@react-email/code-inline": {
+          "optional": true
+        },
+        "@react-email/container": {
+          "optional": true
+        },
+        "@react-email/heading": {
+          "optional": true
+        },
+        "@react-email/hr": {
+          "optional": true
+        },
+        "@react-email/img": {
+          "optional": true
+        },
+        "@react-email/link": {
+          "optional": true
+        },
+        "@react-email/preview": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-email/text": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.6.tgz",
+      "integrity": "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -3160,6 +4494,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
+      "integrity": "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -3177,6 +4551,18 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.79.0.tgz",
+      "integrity": "sha512-p2GKvdbF9d/6C+dtS6iNcSicPr6eUfkvovD60HWlWsD+oOjC483DzFWrzGjNpBwnswhfMRP8Qn3rYA0VWaOfjw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -3465,6 +4851,161 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.96.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
+      "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.96.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.2.tgz",
+      "integrity": "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-core": "5.96.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@triplit/client": {
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@triplit/client/-/client-1.0.50.tgz",
+      "integrity": "sha512-3vjXTSdDQ3fzLDrewCK7elkAQc7CiDg0eZEOZInQbVMFRiakdieO5C2voSnNjSepIYHxDxFSBllgg32QsNpL9Q==",
+      "license": "AGPL-3.0-only",
+      "peer": true,
+      "dependencies": {
+        "@triplit/db": "^1.1.10",
+        "@triplit/logger": "^0.0.3",
+        "comlink": "^4.4.1",
+        "superjson": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@triplit/client/node_modules/@triplit/logger": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@triplit/logger/-/logger-0.0.3.tgz",
+      "integrity": "sha512-hHcoD6/BsNwBtXjEp8Wiy0/YA2SqIYXd1nMukEPBmFkjT7Cd30eqtsBRT0NRq2mIFX2mr5h9JaO27zDToKnwdw==",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@triplit/client/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@triplit/db": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@triplit/db/-/db-1.1.10.tgz",
+      "integrity": "sha512-9BHDrlDvJOyA9Wl8AsmbUSLhilaReA8gpFoWYjS9VEcm5d6TtqKazPQrFm0/o2WNJdrs01+qR6CysAo449MAyA==",
+      "peer": true,
+      "dependencies": {
+        "@triplit/logger": "^0.0.3",
+        "core-js": "^3.41.0",
+        "elen": "^1.0.10",
+        "nanoid": "^5.1.0",
+        "sorted-btree": "^1.8.1",
+        "web-worker": "^1.5.0"
+      },
+      "peerDependencies": {
+        "better-sqlite3": "*",
+        "expo-sqlite": "*",
+        "lmdb": "*",
+        "uuidv7": "*"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "lmdb": {
+          "optional": true
+        },
+        "uuidv7": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@triplit/db/node_modules/@triplit/logger": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@triplit/logger/-/logger-0.0.3.tgz",
+      "integrity": "sha512-hHcoD6/BsNwBtXjEp8Wiy0/YA2SqIYXd1nMukEPBmFkjT7Cd30eqtsBRT0NRq2mIFX2mr5h9JaO27zDToKnwdw==",
+      "peer": true,
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@triplit/db/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@triplit/db/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@triplit/react": {
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@triplit/react/-/react-1.0.51.tgz",
+      "integrity": "sha512-yGmYWACWycrNHMEfnR1k6CQ398ESIBgFeM47fXFhrdhMJ84QgdRk6VF/C21P80D1Rk/AQePfB0TUIaY4U9BRJg==",
+      "peer": true,
+      "dependencies": {
+        "@triplit/client": "^1.0.50"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -4220,6 +5761,28 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@wojtekmaj/react-recaptcha-v3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/react-recaptcha-v3/-/react-recaptcha-v3-0.1.4.tgz",
+      "integrity": "sha512-zszMOdgI+y1Dz3496pRFr3t68n9+OmX/puLQNnOBDC7WrjM+nOKGyjIMCTe+3J14KDvzcxETeiglyDMGl0Yh/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-recaptcha-v3?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4483,6 +6046,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4562,6 +6140,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-call": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.2.tgz",
+      "integrity": "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@better-auth/utils": "^0.3.1",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/brace-expansion": {
@@ -4782,6 +6381,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4795,6 +6401,34 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5047,6 +6681,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -5083,6 +6726,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
+      "license": "MIT"
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5091,6 +6740,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -5121,6 +6790,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5142,6 +6866,13 @@
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elen": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/elen/-/elen-1.0.10.tgz",
+      "integrity": "sha512-ZL799/V/kzxYJ6Wlfktreq6qQWfGc3VkGUQJW5lZQ8/MhsQiKTAwERPfhEwIsV2movRGe2DfV7H2MjRw76Z7Wg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
@@ -5190,6 +6921,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5835,6 +7578,19 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/eventsource": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
+      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
@@ -6305,6 +8061,50 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6691,6 +8491,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -6788,6 +8608,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -6830,11 +8663,19 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.2.tgz",
+      "integrity": "sha512-MpcPtHLE5EmztuFIqB0vzHAWJPpmN1E6L4oo+kze56LIs3MyXIj9ZHMDxqOvkP38gBR7K1v3jqd4WU2+nrfONQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6929,6 +8770,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kysely": {
+      "version": "0.28.15",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.15.tgz",
+      "integrity": "sha512-r2clcf7HLWvDXaVUEvQymXJY4i3bSOIV3xsL/Upy3ZfSv5HeKsk9tsqbBptLvth5qHEIhxeHTA2jNLyQABkLBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -6947,6 +8797,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/levn": {
@@ -7251,7 +9110,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7287,6 +9145,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7353,6 +9223,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mutative": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mutative/-/mutative-1.3.0.tgz",
+      "integrity": "sha512-8MJj6URmOZAV70dpFe1YnSppRTKC4DsMkXQiBDFayLcDI4ljGokHxmpqaBQuDWa4iAxWaJJ1PS8vAmbntjjKmQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -7369,6 +9249,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanostores": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.2.0.tgz",
+      "integrity": "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/napi-postinstall": {
@@ -7534,7 +9429,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7734,6 +9628,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7760,6 +9667,15 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -7909,7 +9825,6 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -8000,11 +9915,19 @@
         }
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -8021,6 +9944,32 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -8050,6 +9999,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-async-script": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-async-script/-/react-async-script-1.2.0.tgz",
+      "integrity": "sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.1"
       }
     },
     "node_modules/react-day-picker": {
@@ -8086,6 +10048,19 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-google-recaptcha": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-google-recaptcha/-/react-google-recaptcha-3.1.0.tgz",
+      "integrity": "sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.0",
+        "react-async-script": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.1"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.72.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
@@ -8107,6 +10082,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.18.tgz",
+      "integrity": "sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -8255,6 +10243,13 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8381,6 +10376,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rou3": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8466,6 +10467,18 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -8478,6 +10491,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -8681,6 +10701,13 @@
         "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
+    },
+    "node_modules/sorted-btree": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sorted-btree/-/sorted-btree-1.8.1.tgz",
+      "integrity": "sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -8898,6 +10925,19 @@
         }
       }
     },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9101,11 +11141,30 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD",
+      "peer": true
+    },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
       "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
@@ -9238,6 +11297,57 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
+      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {
@@ -9440,6 +11550,22 @@
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
       }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@ai-sdk/anthropic": "^3.0.66",
     "@ai-sdk/react": "^3.0.147",
     "@hookform/resolvers": "^5.2.2",
+    "@neondatabase/auth": "^0.2.0-beta.1",
     "@neondatabase/serverless": "^1.0.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/src/app/api/auth/[...path]/route.ts
+++ b/src/app/api/auth/[...path]/route.ts
@@ -1,0 +1,3 @@
+import { auth } from '@/lib/auth/server';
+
+export const { GET, POST } = auth.handler();

--- a/src/app/api/auth/[...path]/route.ts
+++ b/src/app/api/auth/[...path]/route.ts
@@ -1,3 +1,35 @@
 import { auth } from '@/lib/auth/server';
+import type { NextRequest } from 'next/server';
 
-export const { GET, POST } = auth.handler();
+const { GET: _GET, POST: _POST } = auth.handler();
+
+// Neon Auth (Better Auth) validates the Origin header against registered trusted origins.
+// Preview deployments have dynamic URLs (*.vercel.app) that aren't registered, so we
+// rewrite the Origin to the production URL before proxying to Neon's auth service.
+function withCanonicalOrigin(request: NextRequest): Request {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (!appUrl) return request;
+
+  const headers = new Headers(request.headers);
+  headers.set('origin', appUrl);
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: request.body,
+    duplex: 'half',
+  } as RequestInit);
+}
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ path: string[] }> }
+) {
+  return _GET(withCanonicalOrigin(request), ctx);
+}
+
+export async function POST(
+  request: NextRequest,
+  ctx: { params: Promise<{ path: string[] }> }
+) {
+  return _POST(withCanonicalOrigin(request), ctx);
+}

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -4,6 +4,23 @@ import '@/lib/env';
 
 const log = createRouteLogger('members');
 
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function deriveInitials(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .slice(0, 2)
+    .join('');
+}
+
 export async function GET(): Promise<Response> {
   const ctx = log.begin();
   try {
@@ -23,6 +40,46 @@ export async function GET(): Promise<Response> {
     }));
 
     return log.end(ctx, Response.json(members));
+  } catch (error) {
+    log.err(ctx, error);
+    return Response.json({ error: 'Internal error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request): Promise<Response> {
+  const ctx = log.begin();
+  try {
+    const body = await req.json();
+    const { name, role, system_prompt, personality_notes } = body;
+
+    if (!name?.trim() || !role?.trim() || !system_prompt?.trim()) {
+      return log.end(
+        ctx,
+        Response.json({ error: 'name, role, and system_prompt are required' }, { status: 400 })
+      );
+    }
+
+    const baseId = slugify(name.trim());
+    // Ensure uniqueness: append a short suffix if slug already exists
+    const existing = await sql`SELECT id FROM members WHERE id LIKE ${baseId + '%'}`;
+    const id = existing.length === 0 ? baseId : `${baseId}-${existing.length}`;
+    const initials = deriveInitials(name.trim());
+
+    const rows = await sql`
+      INSERT INTO members (id, name, role, initials, system_prompt, personality_notes)
+      VALUES (${id}, ${name.trim()}, ${role.trim()}, ${initials}, ${system_prompt.trim()}, ${personality_notes?.trim() ?? null})
+      RETURNING id, name, role, initials, status, avatar_url
+    `;
+
+    const member = rows[0];
+    log.info(ctx.reqId, 'Member created', { id: member.id, name: member.name });
+    return log.end(
+      ctx,
+      Response.json(
+        { id: member.id, name: member.name, role: member.role, initials: member.initials, status: member.status, avatarUrl: member.avatar_url },
+        { status: 201 }
+      )
+    );
   } catch (error) {
     log.err(ctx, error);
     return Response.json({ error: 'Internal error' }, { status: 500 });

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -15,10 +15,10 @@ export async function GET(): Promise<Response> {
       return log.end(
         ctx,
         Response.json({
-          name: 'Founder',
+          name: '',
           description: '',
           avatarDataUrl: '',
-          initials: 'FO',
+          initials: '',
         })
       );
     }
@@ -45,7 +45,7 @@ export async function PATCH(req: Request): Promise<Response> {
 
     // Build only the fields that were sent
     const updates: Record<string, string> = {};
-    if (typeof name === 'string') updates.name = name.trim() || 'Founder';
+    if (typeof name === 'string') updates.name = name.trim();
     if (typeof description === 'string') updates.description = description;
     if (typeof avatarDataUrl === 'string') updates.avatar_url = avatarDataUrl;
 

--- a/src/app/auth/sign-in/actions.ts
+++ b/src/app/auth/sign-in/actions.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { auth } from '@/lib/auth/server';
+import { redirect } from 'next/navigation';
+
+export async function signInWithEmail(
+  _prevState: { error: string } | null,
+  formData: FormData
+) {
+  const { error } = await auth.signIn.email({
+    email: formData.get('email') as string,
+    password: formData.get('password') as string,
+  });
+
+  if (error) {
+    return { error: error.message || 'Failed to sign in. Try again.' };
+  }
+
+  redirect('/');
+}

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useActionState } from 'react';
 import { signInWithEmail } from './actions';
 
@@ -64,6 +65,13 @@ export default function SignInPage() {
           >
             {isPending ? 'Signing in...' : 'Sign in'}
           </button>
+
+          <p className="text-panel-faint text-center font-mono text-[10px]">
+            Need an account?{' '}
+            <Link href="/auth/sign-up" className="text-panel-muted underline underline-offset-2">
+              Create account
+            </Link>
+          </p>
         </div>
       </form>
     </div>

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useActionState } from 'react';
+import { signInWithEmail } from './actions';
+
+export default function SignInPage() {
+  const [state, formAction, isPending] = useActionState(signInWithEmail, null);
+
+  return (
+    <div className="bg-panel flex min-h-screen flex-col items-center justify-center p-8">
+      <form action={formAction} className="w-full max-w-xs">
+        <div className="border-panel-border mb-8 flex h-14 w-14 items-center justify-center rounded-sm border border-dashed">
+          <span className="text-panel-faint font-mono text-xs">//</span>
+        </div>
+
+        <p className="text-panel-muted mb-6 font-mono text-[9px] tracking-[0.18em] uppercase">
+          Studio Access
+        </p>
+
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="email"
+              className="text-panel-muted font-mono text-[9px] tracking-[0.18em] uppercase"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              autoFocus
+              placeholder="you@example.com"
+              className="border-panel-border bg-panel-input text-panel-foreground placeholder:text-panel-faint w-full rounded-sm border px-3 py-2 text-[13px] outline-none focus:border-panel-text"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="password"
+              className="text-panel-muted font-mono text-[9px] tracking-[0.18em] uppercase"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              placeholder="••••••••"
+              className="border-panel-border bg-panel-input text-panel-foreground placeholder:text-panel-faint w-full rounded-sm border px-3 py-2 text-[13px] outline-none focus:border-panel-text"
+            />
+          </div>
+
+          {state?.error && (
+            <p className="text-destructive font-mono text-[11px]">{state.error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isPending}
+            className="bg-panel-foreground text-panel mt-1 rounded-sm px-4 py-2 text-[13px] font-medium transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isPending ? 'Signing in...' : 'Sign in'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/auth/sign-up/actions.ts
+++ b/src/app/auth/sign-up/actions.ts
@@ -1,0 +1,21 @@
+'use server';
+
+import { auth } from '@/lib/auth/server';
+import { redirect } from 'next/navigation';
+
+export async function signUpWithEmail(
+  _prevState: { error: string } | null,
+  formData: FormData
+) {
+  const { error } = await auth.signUp.email({
+    name: formData.get('name') as string,
+    email: formData.get('email') as string,
+    password: formData.get('password') as string,
+  });
+
+  if (error) {
+    return { error: error.message || 'Failed to create account.' };
+  }
+
+  redirect('/');
+}

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useActionState } from 'react';
 import { signUpWithEmail } from './actions';
 
@@ -81,6 +82,13 @@ export default function SignUpPage() {
           >
             {isPending ? 'Creating account...' : 'Create account'}
           </button>
+
+          <p className="text-panel-faint text-center font-mono text-[10px]">
+            Already have an account?{' '}
+            <Link href="/auth/sign-in" className="text-panel-muted underline underline-offset-2">
+              Sign in
+            </Link>
+          </p>
         </div>
       </form>
     </div>

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useActionState } from 'react';
+import { signUpWithEmail } from './actions';
+
+export default function SignUpPage() {
+  const [state, formAction, isPending] = useActionState(signUpWithEmail, null);
+
+  return (
+    <div className="bg-panel flex min-h-screen flex-col items-center justify-center p-8">
+      <form action={formAction} className="w-full max-w-xs">
+        <div className="border-panel-border mb-8 flex h-14 w-14 items-center justify-center rounded-sm border border-dashed">
+          <span className="text-panel-faint font-mono text-xs">//</span>
+        </div>
+
+        <p className="text-panel-muted mb-6 font-mono text-[9px] tracking-[0.18em] uppercase">
+          Create Account
+        </p>
+
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="name"
+              className="text-panel-muted font-mono text-[9px] tracking-[0.18em] uppercase"
+            >
+              Name
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              required
+              autoFocus
+              placeholder="Your name"
+              className="border-panel-border bg-panel-input text-panel-foreground placeholder:text-panel-faint w-full rounded-sm border px-3 py-2 text-[13px] outline-none focus:border-panel-text"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="email"
+              className="text-panel-muted font-mono text-[9px] tracking-[0.18em] uppercase"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              placeholder="you@example.com"
+              className="border-panel-border bg-panel-input text-panel-foreground placeholder:text-panel-faint w-full rounded-sm border px-3 py-2 text-[13px] outline-none focus:border-panel-text"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="password"
+              className="text-panel-muted font-mono text-[9px] tracking-[0.18em] uppercase"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              placeholder="••••••••"
+              className="border-panel-border bg-panel-input text-panel-foreground placeholder:text-panel-faint w-full rounded-sm border px-3 py-2 text-[13px] outline-none focus:border-panel-text"
+            />
+          </div>
+
+          {state?.error && (
+            <p className="text-destructive font-mono text-[11px]">{state.error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isPending}
+            className="bg-panel-foreground text-panel mt-1 rounded-sm px-4 py-2 text-[13px] font-medium transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isPending ? 'Creating account...' : 'Create account'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,19 +6,22 @@ import { ChatView } from '@/components/modryn/chat-view';
 import { ContextPanel } from '@/components/modryn/context-panel';
 import { InboxView } from '@/components/modryn/inbox-view';
 import { PlaceholderView } from '@/components/modryn/placeholder-view';
+import { SetupView } from '@/components/modryn/setup-view';
 import { MobileHeader } from '@/components/modryn/mobile-header';
 import { MobileDrawer } from '@/components/modryn/mobile-drawer';
 import { MobileTabBar } from '@/components/modryn/mobile-tab-bar';
 import { MobileContextFab } from '@/components/modryn/mobile-context-fab';
 import { useMembers } from '@/hooks/use-members';
+import { useProfile } from '@/lib/use-profile';
 
 export default function ModrynStudio() {
   const [activeView, setActiveView] = useState<View>('chat');
-  const [activeChat, setActiveChat] = useState('peter-thiel');
+  const [activeChat, setActiveChat] = useState('');
   const [contextCollapsed, setContextCollapsed] = useState(true);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const [mobileContextOpen, setMobileContextOpen] = useState(false);
-  const { members } = useMembers();
+  const { members, refetch } = useMembers();
+  const { profile } = useProfile();
 
   const activeMember = members.find((m) => m.id === activeChat) ?? members[0];
 
@@ -34,6 +37,11 @@ export default function ModrynStudio() {
           contextCollapsed={contextCollapsed}
           onToggleContext={() => setContextCollapsed((v) => !v)}
         />
+      )}
+      {activeView === 'chat' && !activeMember && (
+        <div className="bg-panel flex flex-1 flex-col items-center justify-center p-8">
+          <p className="text-panel-muted text-[13px]">Add a team member to start a conversation.</p>
+        </div>
       )}
       {activeView === 'inbox' && <InboxView />}
       {activeView === 'threads' && (
@@ -60,6 +68,8 @@ export default function ModrynStudio() {
     </>
   );
 
+  const centreContent = profile.name === '' ? <SetupView /> : mainContent;
+
   return (
     <div className="bg-background flex h-screen w-screen overflow-hidden">
       {/* —— Desktop layout —— */}
@@ -71,12 +81,13 @@ export default function ModrynStudio() {
           members={members}
           onViewChange={setActiveView}
           onChatSelect={setActiveChat}
+          onMemberAdded={refetch}
         />
       </div>
 
       {/* Center + Right panels — desktop */}
       <div className="hidden min-w-0 flex-1 overflow-hidden md:flex">
-        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{mainContent}</main>
+        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{centreContent}</main>
         {activeView === 'chat' && activeMember && (
           <ContextPanel
             memberName={activeMember.name}
@@ -100,7 +111,7 @@ export default function ModrynStudio() {
         />
 
         {/* Main content */}
-        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{mainContent}</main>
+        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">{centreContent}</main>
 
         {/* Bottom tab bar */}
         <MobileTabBar

--- a/src/components/modryn/add-member-sheet.tsx
+++ b/src/components/modryn/add-member-sheet.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { ChromeLabel } from '@/components/modryn/chrome-label';
+
+interface AddMemberSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onMemberAdded: () => void;
+}
+
+const FIELD_CLASS =
+  'w-full bg-transparent text-sidebar-foreground placeholder:text-sidebar-muted border-b border-sidebar-ring outline-none caret-sidebar-primary text-[13px] pb-1 focus:border-sidebar-primary transition-colors';
+
+export function AddMemberSheet({ open, onOpenChange, onMemberAdded }: AddMemberSheetProps) {
+  const [name, setName] = useState('');
+  const [role, setRole] = useState('');
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [personalityNotes, setPersonalityNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  function reset() {
+    setName('');
+    setRole('');
+    setSystemPrompt('');
+    setPersonalityNotes('');
+    setError('');
+    setSaving(false);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim() || !role.trim() || !systemPrompt.trim()) return;
+    setSaving(true);
+    setError('');
+    try {
+      const res = await fetch('/api/members', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          role: role.trim(),
+          system_prompt: systemPrompt.trim(),
+          personality_notes: personalityNotes.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? 'Failed to create member');
+      }
+      onMemberAdded();
+      onOpenChange(false);
+      reset();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong');
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(v) => {
+        onOpenChange(v);
+        if (!v) reset();
+      }}
+    >
+      <SheetContent side="right" className="border-sidebar-border bg-sidebar w-96 border-l p-0">
+        <SheetHeader className="border-sidebar-border border-b px-6 py-5">
+          <SheetTitle className="text-sidebar-muted text-[13px] font-medium tracking-widest uppercase">
+            Add Member
+          </SheetTitle>
+        </SheetHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-6 overflow-y-auto px-6 pt-8 pb-6">
+          <div className="flex flex-col gap-1.5">
+            <ChromeLabel as="label" className="text-sidebar-muted">
+              Name
+            </ChromeLabel>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Peter Thiel"
+              autoFocus
+              required
+              className={FIELD_CLASS}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <ChromeLabel as="label" className="text-sidebar-muted">
+              Role
+            </ChromeLabel>
+            <input
+              type="text"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              placeholder="AI Strategist"
+              required
+              className={FIELD_CLASS}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <ChromeLabel as="label" className="text-sidebar-muted">
+              System prompt
+            </ChromeLabel>
+            <textarea
+              value={systemPrompt}
+              onChange={(e) => setSystemPrompt(e.target.value)}
+              placeholder="You are… Define this member's thinking style, tone, and context."
+              required
+              rows={7}
+              className="border-sidebar-border bg-sidebar-accent text-sidebar-foreground placeholder:text-sidebar-muted w-full rounded-sm border p-3 text-[12px] leading-relaxed outline-none focus:border-sidebar-ring resize-none"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <ChromeLabel as="label" className="text-sidebar-muted">
+              Personality notes
+              <span className="text-sidebar-ring ml-1 normal-case">(optional)</span>
+            </ChromeLabel>
+            <textarea
+              value={personalityNotes}
+              onChange={(e) => setPersonalityNotes(e.target.value)}
+              placeholder="Human-readable notes about strengths, blind spots, use cases."
+              rows={3}
+              className="border-sidebar-border bg-sidebar-accent text-sidebar-foreground placeholder:text-sidebar-muted w-full rounded-sm border p-3 text-[12px] leading-relaxed outline-none focus:border-sidebar-ring resize-none"
+            />
+          </div>
+
+          {error && (
+            <p className="text-destructive font-mono text-[11px]">{error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={!name.trim() || !role.trim() || !systemPrompt.trim() || saving}
+            className="bg-sidebar-primary text-sidebar-primary-foreground rounded-sm px-4 py-2 text-[13px] font-medium transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {saving ? 'Adding...' : 'Add member'}
+          </button>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/modryn/setup-view.tsx
+++ b/src/components/modryn/setup-view.tsx
@@ -32,9 +32,12 @@ export function SetupView() {
 
         <div className="flex flex-col gap-5">
           <div className="flex flex-col gap-1.5">
-            <ChromeLabel as="label" htmlFor="setup-name" className="text-panel-muted">
+            <label
+              htmlFor="setup-name"
+              className="text-panel-muted font-mono text-[9px] tracking-[0.18em] uppercase"
+            >
               Your name
-            </ChromeLabel>
+            </label>
             <input
               id="setup-name"
               type="text"
@@ -48,10 +51,13 @@ export function SetupView() {
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <ChromeLabel as="label" htmlFor="setup-description" className="text-panel-muted">
+            <label
+              htmlFor="setup-description"
+              className="text-panel-muted font-mono text-[9px] tracking-[0.18em] uppercase"
+            >
               What you&apos;re building
               <span className="text-panel-faint ml-1 normal-case">(optional)</span>
-            </ChromeLabel>
+            </label>
             <input
               id="setup-description"
               type="text"

--- a/src/components/modryn/setup-view.tsx
+++ b/src/components/modryn/setup-view.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+import { ChromeLabel } from '@/components/modryn/chrome-label';
+import { useProfile } from '@/lib/use-profile';
+
+export function SetupView() {
+  const { save } = useProfile();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setSaving(true);
+    await save({ name: trimmed, description: description.trim() });
+    // profile.name is now truthy — parent unmounts this view
+  }
+
+  return (
+    <div className="bg-panel flex flex-1 flex-col items-center justify-center p-8">
+      <form onSubmit={handleSubmit} className="w-full max-w-xs">
+        <div className="border-panel-border mb-8 flex h-14 w-14 items-center justify-center rounded-sm border border-dashed">
+          <span className="text-panel-faint font-mono text-xs">//</span>
+        </div>
+
+        <ChromeLabel as="p" className="text-panel-muted mb-6">
+          Studio Setup
+        </ChromeLabel>
+
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-col gap-1.5">
+            <ChromeLabel as="label" htmlFor="setup-name" className="text-panel-muted">
+              Your name
+            </ChromeLabel>
+            <input
+              id="setup-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+              autoFocus
+              required
+              className="border-panel-border bg-panel-input text-panel-foreground placeholder:text-panel-faint w-full rounded-sm border px-3 py-2 text-[13px] outline-none focus:border-panel-text"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <ChromeLabel as="label" htmlFor="setup-description" className="text-panel-muted">
+              What you&apos;re building
+              <span className="text-panel-faint ml-1 normal-case">(optional)</span>
+            </ChromeLabel>
+            <input
+              id="setup-description"
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="A line about your studio or focus"
+              className="border-panel-border bg-panel-input text-panel-foreground placeholder:text-panel-faint w-full rounded-sm border px-3 py-2 text-[13px] outline-none focus:border-panel-text"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={!name.trim() || saving}
+            className="bg-panel-foreground text-panel disabled:bg-panel-chrome mt-1 rounded-sm px-4 py-2 text-[13px] font-medium transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? 'Entering...' : 'Enter studio'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/modryn/sidebar.tsx
+++ b/src/components/modryn/sidebar.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import { MessageSquare, Inbox, Pencil } from 'lucide-react';
+import { MessageSquare, Inbox, Pencil, Plus } from 'lucide-react';
 import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import { useProfile } from '@/lib/use-profile';
 import { ProfileSheet } from '@/components/modryn/profile-sheet';
+import { AddMemberSheet } from '@/components/modryn/add-member-sheet';
 import { ChromeLabel } from '@/components/modryn/chrome-label';
 import type { AIMember } from '@/hooks/use-members';
 
@@ -28,6 +29,7 @@ interface SidebarProps {
   members: AIMember[];
   onViewChange: (view: View) => void;
   onChatSelect: (memberId: string) => void;
+  onMemberAdded: () => void;
 }
 
 const statusColors: Record<MemberStatus, string> = {
@@ -177,9 +179,11 @@ export function Sidebar({
   members,
   onViewChange,
   onChatSelect,
+  onMemberAdded,
 }: SidebarProps) {
   const { profile, save } = useProfile();
   const [profileOpen, setProfileOpen] = useState(false);
+  const [addMemberOpen, setAddMemberOpen] = useState(false);
 
   return (
     <>
@@ -188,6 +192,14 @@ export function Sidebar({
         onOpenChange={setProfileOpen}
         profile={profile}
         save={save}
+      />
+      <AddMemberSheet
+        open={addMemberOpen}
+        onOpenChange={setAddMemberOpen}
+        onMemberAdded={() => {
+          onMemberAdded();
+          setAddMemberOpen(false);
+        }}
       />
       <aside className="bg-sidebar border-sidebar-border flex h-full border-r">
         {/* Icon rail */}
@@ -231,8 +243,8 @@ export function Sidebar({
         {/* Team roster */}
         <div className="flex w-60 flex-col overflow-y-auto">
           <div className="flex h-18 items-center px-4">
-            <span className="text-sidebar-foreground text-[13px] font-medium tracking-[0.05em] uppercase">
-              Modryn Studio
+            <span className="text-sidebar-foreground truncate text-[13px] font-medium tracking-[0.05em] uppercase">
+              {profile.name || 'Studio'}
             </span>
           </div>
 
@@ -292,27 +304,40 @@ export function Sidebar({
             <ChromeLabel as="p" className="text-sidebar-muted mb-2 px-2">
               AI Members
             </ChromeLabel>
-            {members.map((m) => {
-              const member: Member = {
-                id: m.id,
-                name: m.name,
-                role: m.role,
-                initials: m.initials,
-                status: m.status,
-                isAI: true,
-              };
-              return (
-                <MemberRow
-                  key={member.id}
-                  member={member}
-                  selected={activeChat === member.id && activeView === 'chat'}
-                  onClick={() => {
-                    onViewChange('chat');
-                    onChatSelect(member.id);
-                  }}
-                />
-              );
-            })}
+            {members.length === 0 ? (
+              <p className="text-sidebar-muted px-2 py-1 font-mono text-[11px]">
+                No members — add one
+              </p>
+            ) : (
+              members.map((m) => {
+                const member: Member = {
+                  id: m.id,
+                  name: m.name,
+                  role: m.role,
+                  initials: m.initials,
+                  status: m.status,
+                  isAI: true,
+                };
+                return (
+                  <MemberRow
+                    key={member.id}
+                    member={member}
+                    selected={activeChat === member.id && activeView === 'chat'}
+                    onClick={() => {
+                      onViewChange('chat');
+                      onChatSelect(member.id);
+                    }}
+                  />
+                );
+              })
+            )}
+            <button
+              onClick={() => setAddMemberOpen(true)}
+              className="rounded-card hover:bg-sidebar-accent/45 border-sidebar-border text-sidebar-muted hover:text-sidebar-foreground mt-2 flex w-full items-center gap-2 border border-dashed px-2 py-1.5 transition-colors"
+            >
+              <Plus className="h-3.5 w-3.5" strokeWidth={1.5} />
+              <ChromeLabel className="normal-case tracking-[0.05em]">Add member</ChromeLabel>
+            </button>
           </div>
         </div>
       </aside>

--- a/src/components/site-schema.tsx
+++ b/src/components/site-schema.tsx
@@ -22,10 +22,6 @@ export function SiteSchema() {
             url: site.url,
             logo: `${site.url}/icon.png`,
             description: site.description,
-            founder: {
-              '@type': 'Person',
-              name: site.founder,
-            },
           },
         ]),
       }}

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -4,7 +4,7 @@
 export const site = {
   name: 'Modryn Studio',
   shortName: 'Modryn',
-  url: 'https://app-modryn-studio.vercel.app',
+  url: 'https://app.modrynstudio.com',
   // Base description — used in <meta description>, manifest, JSON-LD
   description:
     'An AI company operating system. Chat with AI team members, assign tasks, log decisions, and run async threads.',

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -7,13 +7,12 @@ export const site = {
   url: 'https://app-modryn-studio.vercel.app',
   // Base description — used in <meta description>, manifest, JSON-LD
   description:
-    'Internal AI company operating system for Modryn Studio. Chat with AI team members, assign tasks, log decisions, and run async threads.',
+    'An AI company operating system. Chat with AI team members, assign tasks, log decisions, and run async threads.',
   // Used as the <title> tag (homepage + fallback) AND social card title.
   ogTitle: 'Modryn Studio — AI Company Operating System',
   ogDescription:
-    'An internal operating system where AI team members modeled after real thinkers hold strategy, push back, and run alongside you.',
+    'An operating system where AI team members hold strategy, push back, and run alongside you.',
   cta: 'Open the studio →', // used in OG images
-  founder: 'Luke Hanner',
   email: 'hello@modryn.studio',
   // Waitlist section copy — not used (monetization: none)
   waitlist: {
@@ -26,10 +25,6 @@ export const site = {
   bg: '#171717',
   // Social profiles — used in footer links and Twitter card metadata.
   social: {
-    twitter: 'https://x.com/lukehanner',
-    twitterHandle: '@lukehanner',
     github: 'https://github.com/modryn-studio/app.modryn.studio',
-    devto: 'https://dev.to/lukehanner',
-    shipordie: 'https://shipordie.club/lukehanner',
   },
 } as const;

--- a/src/hooks/use-members.ts
+++ b/src/hooks/use-members.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export interface AIMember {
   id: string;
@@ -14,6 +14,7 @@ export interface AIMember {
 export function useMembers() {
   const [members, setMembers] = useState<AIMember[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [tick, setTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -35,7 +36,9 @@ export function useMembers() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [tick]);
 
-  return { members, isLoading };
+  const refetch = useCallback(() => setTick((t) => t + 1), []);
+
+  return { members, isLoading, refetch };
 }

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,0 +1,5 @@
+'use client';
+
+import { createAuthClient } from '@neondatabase/auth/next';
+
+export const authClient = createAuthClient();

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -1,0 +1,8 @@
+import { createNeonAuth } from '@neondatabase/auth/next/server';
+
+export const auth = createNeonAuth({
+  baseUrl: process.env.NEON_AUTH_BASE_URL!,
+  cookies: {
+    secret: process.env.NEON_AUTH_COOKIE_SECRET!,
+  },
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -4,6 +4,8 @@ const schema = z.object({
   // Required — app will not start without these
   ANTHROPIC_API_KEY: z.string().min(1, 'ANTHROPIC_API_KEY is required'),
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+  NEON_AUTH_BASE_URL: z.string().min(1, 'NEON_AUTH_BASE_URL is required'),
+  NEON_AUTH_COOKIE_SECRET: z.string().min(1, 'NEON_AUTH_COOKIE_SECRET is required'),
 
   // Optional — boilerplate features, not all active at once
   STRIPE_SECRET_KEY: z.string().optional(),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -21,6 +21,7 @@ const schema = z.object({
   RESEND_SEGMENT_ID: z.string().optional(),
 
   NEXT_PUBLIC_SITE_URL: z.string().optional(),
+  NEXT_PUBLIC_APP_URL: z.string().optional(),
 });
 
 const parsed = schema.safeParse(process.env);

--- a/src/lib/use-profile.ts
+++ b/src/lib/use-profile.ts
@@ -19,15 +19,15 @@ export function getInitials(name: string): string {
       .split(/\s+/)
       .map((w) => w[0]?.toUpperCase() ?? '')
       .slice(0, 2)
-      .join('') || 'FO'
+      .join('')
   );
 }
 
 const DEFAULT: Profile = {
-  name: 'Founder',
+  name: '',
   description: '',
   avatarDataUrl: '',
-  initials: 'FO',
+  initials: '',
 };
 
 function readCache(): Profile {
@@ -89,7 +89,7 @@ export function useProfile() {
   const save = useCallback(
     async (updates: Partial<Omit<Profile, 'initials'>>) => {
       // Optimistic update
-      const name = (updates.name ?? profile.name).trim() || 'Founder';
+      const name = (updates.name ?? profile.name).trim();
       const next: Profile = { ...profile, ...updates, name, initials: getInitials(name) };
       setProfile(next);
       writeCache(next);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,9 @@
+import { auth } from '@/lib/auth/server';
+
+export default auth.middleware({ loginUrl: '/auth/sign-in' });
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|brand|icon|opengraph-image|manifest|auth).*)',
+  ],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { auth } from '@/lib/auth/server';
 
-export default auth.middleware({ loginUrl: '/auth/sign-in' });
+export default auth.middleware({ loginUrl: '/auth/sign-up' });
 
 export const config = {
   matcher: [


### PR DESCRIPTION
- Remove hardcoded Peter Thiel seed from 001_initial.sql; add founder_profile
  table (was missing from migrations entirely)
- Add 003_remove_peter_thiel.sql cleanup migration for existing databases
- POST /api/members: new handler — server derives id (slug) and initials
- Profile API + use-profile: empty defaults so first-run state is detectable
  via profile.name === ''
- SetupView: inline warm cream panel (not a modal — per brand.md) shown on
  first load; user enters name/description to enter the studio
- AddMemberSheet: dark chrome slide-in sheet matching ProfileSheet pattern;
  POST to /api/members on submit
- Sidebar: dynamic studio name from profile, + Add Member button, empty member
  state; useMembers gains refetch() for post-create refresh
- page.tsx: renders SetupView when profile not set, empty chat nudge when no
  members, removes 'peter-thiel' hardcoded activeChat
- site.ts: remove founder/Luke-specific fields and personal social links
- brand.md: add missing tokens (sidebar-rail, sidebar-primary,
  panel-foreground-hover), fix sidebar-muted value, document secondary/
  status-active redundancy, add Component Zones section, remove Luke copy

https://claude.ai/code/session_01CVAnHY5dkm6DVxn9GzNSZm